### PR TITLE
Disables the april fools decal color randomization

### DIFF
--- a/code/game/objects/effects/decals/turfdecal/flooring_decals.dm
+++ b/code/game/objects/effects/decals/turfdecal/flooring_decals.dm
@@ -2,19 +2,19 @@
 	layer = TURF_PLATING_DECAL_LAYER
 	icon_state = "corner_white"
 
-/obj/effect/turf_decal/corner/Initialize()
+/* /obj/effect/turf_decal/corner/Initialize() // Echo 13 - Start - Fools no more (no mirror file necessary)
 	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
 		color = "#[random_short_color()]"
-	. = ..()
+	. = ..() */ // Echo 13 - End - Fools no more (no mirror file necessary)
 
 /obj/effect/turf_decal/trimline
 	layer = TURF_PLATING_DECAL_LAYER
 	icon_state = "trimline_box"
 
-/obj/effect/turf_decal/trimline/Initialize()
+/* /obj/effect/turf_decal/trimline/Initialize() // Echo 13 - Start - Fools no more (no mirror file necessary)
 	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
 		color = "#[random_short_color()]"
-	. = ..()
+	. = ..() */ // Echo 13 - End - Fools no more (no mirror file necessary)
 
 //forgive me for my sins
 #define TURF_DECAL_COLOR_HELPER(color_name, tile_color, tile_alpha)		\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's really self-explanatory but.
Comments out the proc redefinitions that add the color randomization and nothing else. Following the same format for modular changes but specifying there is no modular file as the proc redefinitions only randomize the colors and then call the parent(or previous definition)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This is bad
![image](https://github.com/Sector-Echo-13-Team/Echo-SS13/assets/88832933/93fd9d2a-fb67-400b-b734-beb740d5b3d7)

This is good
![image](https://github.com/Sector-Echo-13-Team/Echo-SS13/assets/88832933/ed6398ee-c81c-4b4a-9751-05637ab7c9f7)

## Changelog

:cl:
del: April fools no longer randomizes decal colors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
