### PR TITLE
Disables the Arrowhead and Nemo class vessels until further notice

### DIFF
--- a/_maps/configs/independent_arrowhead.json
+++ b/_maps/configs/independent_arrowhead.json
@@ -38,5 +38,5 @@
 			"slots": 2
 		}
 	},
-	"enabled": true
+	"enabled": false
 }

--- a/_maps/configs/independent_echo_nemo.json
+++ b/_maps/configs/independent_echo_nemo.json
@@ -50,5 +50,5 @@
 			"slots": 1
 		}
 	},
-	"enabled": true
+	"enabled": false
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title.

## Why It's Good For The Game
Right now they spawn, but they spawn with holes in them. 
I'll update the arrowhead and possibly the nemo once I get a feel for modern shiptest code and what adjustments I should make to them since they're over a year old at this point and shiptest code has changed a fair bit.
## Changelog

:cl:
config: The Arrowhead-class and Nemo-class can no longer be spawned until further notice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
